### PR TITLE
[#3] Deploy(yml): mysql 연결, docker compose 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ out/
 
 ### package files ###
 *.jar
+
+### secrets ###
+.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '3'
+services:
+  mysql:
+    container_name: shoutify-mysql
+    image: mysql:latest
+    # 한글 사용 위해 utf8mb4 설정
+    command:
+      - '--character-set-server=utf8mb4'
+      - '--collation-server=utf8mb4_unicode_ci'
+    ports:
+      - '${DB_PORT}:3306'
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: ${DB_NAME}
+      MYSQL_USER: ${DB_USERNAME}
+      MYSQL_PASSWORD: ${DB_PASSWORD}
+      TZ: Asia/Seoul

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,27 @@
 spring:
   application:
     name: shoutify
+
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    # 이미 설치되어 있을 수 있어서 포트 번호를 임의로 변경
+    url: jdbc:mysql://localhost:${DB_PORT}/${DB_NAME}?createDatabaseIfNotExist=true&serverTimezone=UTC&characterEncoding=UTF-8
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+  jpa:
+    properties:
+      hibernate:
+        format_sql: true
+    hibernate:
+      ddl-auto: none
+    show-sql: true
+  # 404인 경우, static 리소스 참고하지 않고, 예외 핸들러에서 처리하도록 함.
+  web:
+    resources:
+      add-mappings: false
+
+# log
+# log level 설정, 예: info, debug, warn, error
+logging:
+  level:
+    org.springframework.jdbc.datasource.init.ScriptUtils: debug


### PR DESCRIPTION
## 작업 요약
- mysql datasource 연결(yml), docker-compose 로 관리
- 환경 변수 관리 시 실수로 원격 저장소에 올리는 일 방지하기 위해 gitignore에 .env 추가

close #3 

## 작업 설명

### AS-IS
- datasource 연결되어 있지 않아 spring boot가 실행되지 않음.

### TO-BE
- 정상 동작, docker로 mysql 버전, 계정 등 관리

## 리뷰 요구사항
- 다른 좋은 방법이 있다면 제안해 주세요.
- docker-compose 이렇게 쓰는 게 아니라면, 말해주세요. 얼마든지 환영이요.

## 참고
- 우선, 배포 일정이 꽤 뒤라서 개발, 배포 yml 분리는 따로 진행하지 않았습니다.
- [노션 - 실행 방법](https://www.notion.so/hannanana/20433717f9138082a60ce21c51d25db9?source=copy_link) 참고해 주세요. (간략: docker 설치, docker 실행, docker-compose 명령어 실행, intelliJ spring 실행)

## 확인 사항

- [x] 내 코드에 대해 self-review를 진행했는지?
- [x] 내 코드가 project 규칙에 만족하는지?
- [x] sonarlint, IDE, log 등에서 새로운 warning이 없는 걸 확인했는지?
- [x] 적절한 테스트 코드를 추가했는지?
- [x] 모든 테스트에 통과하는 걸 확인했는지?
- [x] 필요한 문서 생성/수정이 진행되었는지?
