### PR TITLE
[#16]Fix(ex): Controller 추가 시 의존성 주입이 되지 않아 Test 실패해 test할 controller 명시

### DIFF
--- a/src/test/java/today/sesac/shoutify/global/advice/GlobalExceptionHandlerTest.java
+++ b/src/test/java/today/sesac/shoutify/global/advice/GlobalExceptionHandlerTest.java
@@ -9,7 +9,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
@@ -28,8 +27,7 @@ import today.sesac.shoutify.global.exception.PermissionRequiredException;
 /**
  * 전역 예외 처리 테스트
  */
-@WebMvcTest
-@Import(GlobalExceptionHandler.class)
+@WebMvcTest(controllers = GlobalExceptionHandlerTest.class)
 class GlobalExceptionHandlerTest {
 
 	static final String IS_SUCCESS = "$.isSuccess";


### PR DESCRIPTION
## 작업 요약
- 잘못된 WebMvcTest 설정으로 발생한 테스트 실패 -> test 대상 controller 명시해 해결
  - NoSuchBeanDefinitionException, UnsatisfiedDependencyException

resolve #16  

### PR 타입

- [ ] 기능 구현
- [X] 테스트 코드 작성
- [ ] 코드 리팩토링
- [ ] 문서 작성
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 작업 설명

### AS-IS
 WebMvcTest에 테스트할 controller를 명시하지 않아 `@Controller, @ControllerAdvice, @JsonComponent` 이 붙은 Bean 전부 주입함.
 이때, AiController의 AiService는 Bean 등록 대상이 아니기 때문에, 해당 빈을 찾을 수 없어서  NoSuchBeanDefinitionException 발생, 의존성 주입 실패로 UnsatisfiedDependencyException 발생
```
@WebMvcTest
@Import(GlobalExceptionHandler.class)
class GlobalExceptionHandlerTest { ... }
```

### TO-BE
- GlobalExceptionHandlerTest 빈만 주입함.
```
@WebMvcTest(controllers = GlobalExceptionHandlerTest.class)
class GlobalExceptionHandlerTest { ... }
```

### 검증 방법
- X

## 리뷰 요구사항
- 혹시 또 놓친 부분이 있다면 말씀해 주세요...

## 기타
- [@WebMvcTest - spring 문서](https://docs.spring.io/spring-boot/3.3/api/java/org/springframework/boot/test/autoconfigure/web/servlet/WebMvcTest.html)
- [[Spring] SpringBoot 테스트 시 @WebMvcTest와 @SpringBootTest의 차이](https://ksh-coding.tistory.com/53)

## 확인 사항

- [x] label, project, milestone 할당했나요?
- [x] 내 코드에 대해 self-review 진행했나요?(draft로 pr 발행 -> self-review -> Assignees 할당)
- [x] 내 코드가 project 규칙에 만족하나요?(주석, 코드 스타일, 불필요한 import문 제거 등)
- [x] sonarlint, IDE, log 등에서 새로운 warning이 없는 걸 확인했나요?
- [x] 모든 테스트에 통과하는 걸 확인했나요?
- [x] 필요한 문서 생성/수정이 진행되었나요?
