### PR TITLE
[#36] 소셜 로그인 구현 (정상동작, 구글만, 세션 )

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,37 +1,39 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.5.0'
-	id 'io.spring.dependency-management' version '1.1.7'
+    id 'java'
+    id 'org.springframework.boot' version '3.5.0'
+    id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'today.sesac'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.mysql:mysql-connector-j'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation "org.springframework.boot:spring-boot-starter-security"
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    compileOnly 'org.projectlombok:lombok'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 tasks.named('test') {

--- a/src/main/java/today/sesac/shoutify/auth/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/today/sesac/shoutify/auth/OAuth2AuthenticationSuccessHandler.java
@@ -13,6 +13,9 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 
+/**
+ * OAuth2 로그인 성공 시 작동하는 동작들을 규정하는 클래스입니다.
+ */
 @Slf4j
 @Component
 public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
@@ -24,9 +27,10 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 	@Override
 	public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
 		Authentication authentication) throws IOException, ServletException {
+
 		RedirectStrategy redirectStrategy = new DefaultRedirectStrategy();
 		redirectStrategy.sendRedirect(request, response, "http://localhost:3000");
 
-		//TODO: 소설 로그인 이후 새로 아이디 생성되었으면 201 반환, 아닐 경우 200 반환
+		//TODO: 소설 로그인 이후 새로 아이디 생성되었으면 201 반환, 아닐 경우 200 반환 구현하기
 	}
 }

--- a/src/main/java/today/sesac/shoutify/auth/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/today/sesac/shoutify/auth/OAuth2AuthenticationSuccessHandler.java
@@ -17,12 +17,16 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
+	/**
+	 * 홈 페이지로 리다이렉트
+	 * TODO: 원래 로그인하려던 페이지로 보내주기(프론트 구현 필요)
+	 */
 	@Override
 	public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
 		Authentication authentication) throws IOException, ServletException {
-
 		RedirectStrategy redirectStrategy = new DefaultRedirectStrategy();
 		redirectStrategy.sendRedirect(request, response, "http://localhost:3000");
 
+		//TODO: 소설 로그인 이후 새로 아이디 생성되었으면 201 반환, 아닐 경우 200 반환
 	}
 }

--- a/src/main/java/today/sesac/shoutify/auth/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/today/sesac/shoutify/auth/OAuth2AuthenticationSuccessHandler.java
@@ -17,21 +17,21 @@ import today.sesac.shoutify.member.entity.RoleType;
 import today.sesac.shoutify.member.entity.SocialType;
 
 /**
- * OAuth2 로그인 성공 시 작동하는 동작들을 규정하는 클래스입니다.
+ * 소셜 로그인이 성공했을 떄 마지막으로 작동하는 동작들을 설정하는 클래스입니다.
  */
 @Slf4j
 @Component
 public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
 	/**
-	 * 홈 페이지로 리다이렉트
+	 * 로그인 성공 시 홈(/) 페이지로 리다이렉트
 	 * TODO: 원래 로그인하려던 페이지로 보내주기(프론트 구현 필요)
 	 */
 	@Override
 	public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
 		Authentication authentication) throws IOException, ServletException {
 
-		//TODO: 팀원 확인 용 로그 - 테스트코드 직성 이후 삭제하기
+		//TODO: 팀원 확인용 로그 - 테스트코드 직성 이후 삭제하기
 		boolean authenticated = authentication.isAuthenticated();
 		CurrentUser currentUser = (CurrentUser)authentication.getPrincipal();
 		Long memberId = currentUser.getMemberId();

--- a/src/main/java/today/sesac/shoutify/auth/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/today/sesac/shoutify/auth/OAuth2AuthenticationSuccessHandler.java
@@ -12,6 +12,9 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
+import today.sesac.shoutify.auth.service.CurrentUser;
+import today.sesac.shoutify.member.entity.RoleType;
+import today.sesac.shoutify.member.entity.SocialType;
 
 /**
  * OAuth2 로그인 성공 시 작동하는 동작들을 규정하는 클래스입니다.
@@ -28,9 +31,21 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 	public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
 		Authentication authentication) throws IOException, ServletException {
 
+		//TODO: 팀원 확인 용 로그 - 테스트코드 직성 이후 삭제하기
+		boolean authenticated = authentication.isAuthenticated();
+		CurrentUser currentUser = (CurrentUser)authentication.getPrincipal();
+		Long memberId = currentUser.getMemberId();
+		RoleType roleType = currentUser.getRoleType();
+		SocialType socialType = currentUser.getSocialType();
+		String username = currentUser.getUsername();
+		log.info("authenticated = {}", authenticated);
+		log.info("memberId = {}, roleType = {}, socialType = {}, username = {}",
+			memberId, roleType, socialType, username);
+		log.info("-----authentication success!!-----");
+
+		//TODO: 소설 로그인 이후 새로 아이디 생성되었으면 201 반환, 아닐 경우 200 반환 구현하기
 		RedirectStrategy redirectStrategy = new DefaultRedirectStrategy();
 		redirectStrategy.sendRedirect(request, response, "http://localhost:3000");
 
-		//TODO: 소설 로그인 이후 새로 아이디 생성되었으면 201 반환, 아닐 경우 200 반환 구현하기
 	}
 }

--- a/src/main/java/today/sesac/shoutify/auth/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/today/sesac/shoutify/auth/OAuth2AuthenticationSuccessHandler.java
@@ -1,0 +1,28 @@
+package today.sesac.shoutify.auth;
+
+import java.io.IOException;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.DefaultRedirectStrategy;
+import org.springframework.security.web.RedirectStrategy;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+	@Override
+	public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+		Authentication authentication) throws IOException, ServletException {
+
+		RedirectStrategy redirectStrategy = new DefaultRedirectStrategy();
+		redirectStrategy.sendRedirect(request, response, "http://localhost:3000");
+
+	}
+}

--- a/src/main/java/today/sesac/shoutify/auth/config/SecurityConfig.java
+++ b/src/main/java/today/sesac/shoutify/auth/config/SecurityConfig.java
@@ -12,11 +12,17 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import lombok.RequiredArgsConstructor;
+import today.sesac.shoutify.auth.OAuth2AuthenticationSuccessHandler;
+
 /**
  * TODO: SecurityConfig의 위치 도메인 패키지 안에서 config 패키지를 만들고 넣을지, 공통 패키지를 안에 config 패키지를 만들지 논의 필요
  */
 @Configuration
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+	private final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
 
 	@Bean
 	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -37,6 +43,7 @@ public class SecurityConfig {
 					.baseUri("/api/oauth2/authorization"))
 				.redirectionEndpoint(oAuth2 -> oAuth2
 					.baseUri("/login/oauth2/code/*"))
+				.successHandler(oAuth2AuthenticationSuccessHandler)
 			)
 		;
 
@@ -44,7 +51,7 @@ public class SecurityConfig {
 	}
 
 	/**
-	 * TODO: CORS 설정 시큐리티 설저 안에서 정할지, 아니면 따로 팔지 고민 필요
+	 * TODO: CORS 설정 시큐리티 설정 안에서 정할지, 아니면 따로 팔지 고민 필요
 	 */
 	@Bean
 	public CorsConfigurationSource corsConfigurationSource() {

--- a/src/main/java/today/sesac/shoutify/auth/config/SecurityConfig.java
+++ b/src/main/java/today/sesac/shoutify/auth/config/SecurityConfig.java
@@ -1,0 +1,64 @@
+package today.sesac.shoutify.auth.config;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+/**
+ * TODO: SecurityConfig의 위치 도메인 패키지 안에서 config 패키지를 만들고 넣을지, 공통 패키지를 안에 config 패키지를 만들지 논의 필요
+ */
+@Configuration
+public class SecurityConfig {
+
+	@Bean
+	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+		http
+			.cors(cors -> cors.configurationSource(corsConfigurationSource()))
+			.csrf(AbstractHttpConfigurer::disable)
+			.formLogin(AbstractHttpConfigurer::disable)
+			.httpBasic(AbstractHttpConfigurer::disable)
+			.authorizeHttpRequests(auth -> auth
+				.requestMatchers(
+					"/api/oauth2/authorization",
+					"/login/oauth2/code/*"
+				).permitAll()
+				.anyRequest().authenticated()
+			)
+			.oauth2Login(oauth2 -> oauth2
+				.authorizationEndpoint(oAuth2 -> oAuth2
+					.baseUri("/api/oauth2/authorization"))
+				.redirectionEndpoint(oAuth2 -> oAuth2
+					.baseUri("/login/oauth2/code/*"))
+			)
+		;
+
+		return http.build();
+	}
+
+	/**
+	 * TODO: CORS 설정 시큐리티 설저 안에서 정할지, 아니면 따로 팔지 고민 필요
+	 */
+	@Bean
+	public CorsConfigurationSource corsConfigurationSource() {
+		CorsConfiguration configuration = new CorsConfiguration();
+
+		configuration.setAllowedOrigins(List.of("http://localhost:3000"));
+		configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+		configuration.setAllowedHeaders(List.of("*"));
+		configuration.setAllowCredentials(true);
+		configuration.setMaxAge(3600L);
+
+		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+		source.registerCorsConfiguration("/**", configuration);
+
+		return source;
+	}
+}

--- a/src/main/java/today/sesac/shoutify/auth/config/SecurityConfig.java
+++ b/src/main/java/today/sesac/shoutify/auth/config/SecurityConfig.java
@@ -14,6 +14,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import lombok.RequiredArgsConstructor;
 import today.sesac.shoutify.auth.OAuth2AuthenticationSuccessHandler;
+import today.sesac.shoutify.auth.service.OAuth2UserCustomService;
 
 /**
  * TODO: SecurityConfig의 위치 도메인 패키지 안에서 config 패키지를 만들고 넣을지, 공통 패키지를 안에 config 패키지를 만들지 논의 필요
@@ -23,6 +24,7 @@ import today.sesac.shoutify.auth.OAuth2AuthenticationSuccessHandler;
 public class SecurityConfig {
 
 	private final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
+	private final OAuth2UserCustomService oAuth2UserCustomService;
 
 	@Bean
 	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -43,6 +45,9 @@ public class SecurityConfig {
 					.baseUri("/api/oauth2/authorization"))
 				.redirectionEndpoint(oAuth2 -> oAuth2
 					.baseUri("/login/oauth2/code/*"))
+				.userInfoEndpoint(userInfoEndpointConfig ->
+					userInfoEndpointConfig
+						.userService(oAuth2UserCustomService))
 				.successHandler(oAuth2AuthenticationSuccessHandler)
 			)
 		;

--- a/src/main/java/today/sesac/shoutify/auth/config/SecurityConfig.java
+++ b/src/main/java/today/sesac/shoutify/auth/config/SecurityConfig.java
@@ -50,7 +50,7 @@ public class SecurityConfig {
 				.userInfoEndpoint(userInfoEndpointConfig ->
 					userInfoEndpointConfig
 						.userService(oAuth2UserCustomService))
-				.successHandler(oAuth2AuthenticationSuccessHandler)
+				.successHandler(oAuth2AuthenticationSuccessHandler) //TODO: 실패 시 handler도 추가하기
 			)
 		;
 

--- a/src/main/java/today/sesac/shoutify/auth/config/SecurityConfig.java
+++ b/src/main/java/today/sesac/shoutify/auth/config/SecurityConfig.java
@@ -18,6 +18,7 @@ import today.sesac.shoutify.auth.service.OAuth2UserCustomService;
 
 /**
  * TODO: SecurityConfig의 위치 도메인 패키지 안에서 config 패키지를 만들고 넣을지, 공통 패키지를 안에 config 패키지를 만들지 논의 필요
+ * 스프링 시큐리티 설정을 관리하는 클래스입니다
  */
 @Configuration
 @RequiredArgsConstructor
@@ -36,7 +37,8 @@ public class SecurityConfig {
 			.authorizeHttpRequests(auth -> auth
 				.requestMatchers(
 					"/api/oauth2/authorization",
-					"/login/oauth2/code/*"
+					"/login/oauth2/code/*",
+					"/api/**"  // TODO: 팀원 기능 구현에 방해되지 않도록 임시 설정, 추후 삭제할 것
 				).permitAll()
 				.anyRequest().authenticated()
 			)
@@ -57,6 +59,7 @@ public class SecurityConfig {
 
 	/**
 	 * TODO: CORS 설정 시큐리티 설정 안에서 정할지, 아니면 따로 팔지 고민 필요
+	 * CORS 설정
 	 */
 	@Bean
 	public CorsConfigurationSource corsConfigurationSource() {

--- a/src/main/java/today/sesac/shoutify/auth/controller/AuthController.java
+++ b/src/main/java/today/sesac/shoutify/auth/controller/AuthController.java
@@ -24,9 +24,11 @@ public class AuthController {
 		Long memberId = currentUser.getMemberId();
 		RoleType roleType = currentUser.getRoleType();
 		SocialType socialType = currentUser.getSocialType();
-		String email = currentUser.getUsername();
+		String username = currentUser.getUsername();
+		log.info("checkAuthStatus: memberId = {}, roleType = {}, socialType = {}, username = {}",
+			memberId, roleType, socialType, username);
 
-		CheckStatusResponse response = new CheckStatusResponse(memberId, roleType, socialType, email);
+		CheckStatusResponse response = new CheckStatusResponse(memberId, roleType, socialType, username);
 
 		return ApiResponse.success(response);
 	}

--- a/src/main/java/today/sesac/shoutify/auth/controller/AuthController.java
+++ b/src/main/java/today/sesac/shoutify/auth/controller/AuthController.java
@@ -1,0 +1,29 @@
+package today.sesac.shoutify.auth.controller;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+	@GetMapping("/status")
+	public ResponseEntity<?> checkAuthStatus(@AuthenticationPrincipal OAuth2User oAuth2User) {
+		String email = oAuth2User.getAttribute("email");
+		Map<String, String> response = new HashMap<>();
+		response.put("email", email);
+		return ResponseEntity.ok(response);
+	}
+}

--- a/src/main/java/today/sesac/shoutify/auth/controller/AuthController.java
+++ b/src/main/java/today/sesac/shoutify/auth/controller/AuthController.java
@@ -1,17 +1,16 @@
 package today.sesac.shoutify.auth.controller;
 
-import java.util.HashMap;
-import java.util.Map;
-
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import today.sesac.shoutify.auth.service.CurrentUser;
+import today.sesac.shoutify.global.response.ApiResponse;
+import today.sesac.shoutify.member.entity.RoleType;
+import today.sesac.shoutify.member.entity.SocialType;
 
 @Slf4j
 @RestController
@@ -19,11 +18,16 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class AuthController {
 
+	// TODO: 로그인 상태 확인용 임시 메서드 - 삭제 예정
 	@GetMapping("/status")
-	public ResponseEntity<?> checkAuthStatus(@AuthenticationPrincipal OAuth2User oAuth2User) {
-		String email = oAuth2User.getAttribute("email");
-		Map<String, String> response = new HashMap<>();
-		response.put("email", email);
-		return ResponseEntity.ok(response);
+	public ApiResponse<?> checkAuthStatus(@AuthenticationPrincipal CurrentUser currentUser) {
+		Long memberId = currentUser.getMemberId();
+		RoleType roleType = currentUser.getRoleType();
+		SocialType socialType = currentUser.getSocialType();
+		String email = currentUser.getUsername();
+
+		CheckStatusResponse response = new CheckStatusResponse(memberId, roleType, socialType, email);
+
+		return ApiResponse.success(response);
 	}
 }

--- a/src/main/java/today/sesac/shoutify/auth/controller/AuthController.java
+++ b/src/main/java/today/sesac/shoutify/auth/controller/AuthController.java
@@ -9,8 +9,10 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import today.sesac.shoutify.auth.service.CurrentUser;
 import today.sesac.shoutify.global.response.ApiResponse;
+import today.sesac.shoutify.member.entity.Member;
 import today.sesac.shoutify.member.entity.RoleType;
 import today.sesac.shoutify.member.entity.SocialType;
+import today.sesac.shoutify.member.service.MemberService;
 
 @Slf4j
 @RestController
@@ -18,10 +20,15 @@ import today.sesac.shoutify.member.entity.SocialType;
 @RequiredArgsConstructor
 public class AuthController {
 
+	private final MemberService memberService;
+
 	// TODO: 로그인 상태 확인용 임시 메서드 - 삭제 예정
 	@GetMapping("/status")
 	public ApiResponse<?> checkAuthStatus(@AuthenticationPrincipal CurrentUser currentUser) {
 		Long memberId = currentUser.getMemberId();
+		Member member = memberService.findById(memberId);
+		log.info("checkAuthStatus: member = {}, nickname = {}", member, member.getNickname());
+
 		RoleType roleType = currentUser.getRoleType();
 		SocialType socialType = currentUser.getSocialType();
 		String username = currentUser.getUsername();

--- a/src/main/java/today/sesac/shoutify/auth/controller/CheckStatusResponse.java
+++ b/src/main/java/today/sesac/shoutify/auth/controller/CheckStatusResponse.java
@@ -13,5 +13,5 @@ public class CheckStatusResponse {
 	private Long memberId;
 	private RoleType roleType;
 	private SocialType socialType;
-	private String email;
+	private String username;
 }

--- a/src/main/java/today/sesac/shoutify/auth/controller/CheckStatusResponse.java
+++ b/src/main/java/today/sesac/shoutify/auth/controller/CheckStatusResponse.java
@@ -1,0 +1,17 @@
+package today.sesac.shoutify.auth.controller;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import today.sesac.shoutify.member.entity.RoleType;
+import today.sesac.shoutify.member.entity.SocialType;
+
+// TODO: 로그인 상태 확인용 임시 DTO - 삭제 예정
+@Data
+@AllArgsConstructor
+public class CheckStatusResponse {
+
+	private Long memberId;
+	private RoleType roleType;
+	private SocialType socialType;
+	private String email;
+}

--- a/src/main/java/today/sesac/shoutify/auth/service/CurrentUser.java
+++ b/src/main/java/today/sesac/shoutify/auth/service/CurrentUser.java
@@ -12,10 +12,11 @@ import today.sesac.shoutify.member.entity.RoleType;
 import today.sesac.shoutify.member.entity.SocialType;
 
 /**
- * OAuth2 로그인 구현에서 사용자의 인증 정보를 저장하는 클래스입니다.
+ * 소셜 로그인을 할 때 사용자의 인증 정보를 저장하는 클래스입니다.
  * memberId 등 추가적인 정보를 꺼내 쓸 수 있도록 커스텀했습니다.
  * TODO: 일반 로그인 구현 시 userDetails를 동시에 구현할지 등 인증 정보를 일괄적으로 관리할 방법 고민하기
  * TODO: 패키지 위치 고민 필요
+ * TODO: 필드 값 종류와 메서드 고민하기. 스프링 시큐리티의 목적에 맞도록 설계할 것
  */
 @Getter
 public class CurrentUser implements OAuth2User {

--- a/src/main/java/today/sesac/shoutify/auth/service/CurrentUser.java
+++ b/src/main/java/today/sesac/shoutify/auth/service/CurrentUser.java
@@ -11,6 +11,12 @@ import lombok.Getter;
 import today.sesac.shoutify.member.entity.RoleType;
 import today.sesac.shoutify.member.entity.SocialType;
 
+/**
+ * OAuth2 로그인 구현에서 사용자의 인증 정보를 저장하는 클래스입니다.
+ * memberId 등 추가적인 정보를 꺼내 쓸 수 있도록 커스텀했습니다.
+ * TODO: 일반 로그인 구현 시 userDetails를 동시에 구현할지 등 인증 정보를 일괄적으로 관리할 방법 고민하기
+ * TODO: 패키지 위치 고민 필요
+ */
 @Getter
 public class CurrentUser implements OAuth2User {
 

--- a/src/main/java/today/sesac/shoutify/auth/service/CurrentUser.java
+++ b/src/main/java/today/sesac/shoutify/auth/service/CurrentUser.java
@@ -1,0 +1,52 @@
+package today.sesac.shoutify.auth.service;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import lombok.Getter;
+import today.sesac.shoutify.member.entity.RoleType;
+import today.sesac.shoutify.member.entity.SocialType;
+
+@Getter
+public class CurrentUser implements OAuth2User {
+
+	private final Long memberId;
+	private final RoleType roleType;
+	private final SocialType socialType;
+	private final String username;
+
+	@Override
+	public <A> A getAttribute(String name) {
+		return OAuth2User.super.getAttribute(name);
+	}
+
+	@Override
+	public Map<String, Object> getAttributes() {
+		return Map.of();
+	}
+
+	@Override
+	public Collection<? extends GrantedAuthority> getAuthorities() {
+		return List.of();
+	}
+
+	@Override
+	public String getName() {
+		return this.username;
+	}
+
+	CurrentUser(Long memberId, RoleType roleType, SocialType socialType, String username) {
+		this.memberId = memberId;
+		this.roleType = roleType;
+		this.socialType = socialType;
+		this.username = username;
+	}
+
+	public static CurrentUser create(Long memberId, RoleType roleType, SocialType socialType, String username) {
+		return new CurrentUser(memberId, roleType, socialType, username);
+	}
+}

--- a/src/main/java/today/sesac/shoutify/auth/service/OAuth2UserCustomService.java
+++ b/src/main/java/today/sesac/shoutify/auth/service/OAuth2UserCustomService.java
@@ -15,7 +15,7 @@ import today.sesac.shoutify.member.exception.MemberNotFoundException;
 import today.sesac.shoutify.member.service.MemberService;
 
 /**
- * 소셜 로그인 과정에서
+ * 소셜 로그인 과정에서 리소스 서버로부터 사용자 정보를 받을 때, 사용자 정보를 가공할 수 있도록 설정하는 클래스입니다.
  */
 @Slf4j
 @Service

--- a/src/main/java/today/sesac/shoutify/auth/service/OAuth2UserCustomService.java
+++ b/src/main/java/today/sesac/shoutify/auth/service/OAuth2UserCustomService.java
@@ -31,7 +31,7 @@ public class OAuth2UserCustomService extends DefaultOAuth2UserService {
 
 		// 소셜 로그인 타입 확인
 		String registrationId = userRequest.getClientRegistration().getRegistrationId();
-		log.info("loadUser.registrationId: {}", registrationId);
+		log.info("loadUser.registrationId: {}", registrationId); // ex.google
 		SocialType socialType = null;
 		if (registrationId.equals("google")) {
 			socialType = SocialType.GOOGLE;

--- a/src/main/java/today/sesac/shoutify/auth/service/OAuth2UserCustomService.java
+++ b/src/main/java/today/sesac/shoutify/auth/service/OAuth2UserCustomService.java
@@ -31,9 +31,11 @@ public class OAuth2UserCustomService extends DefaultOAuth2UserService {
 		if (registrationId.equals("google")) {
 			socialType = SocialType.GOOGLE;
 		}
+		log.info("socialType: {}", socialType);
 
 		// TODO: oauth2User 형식에 맞게 변환
 		String email = oAuth2User.getAttribute("email");
+		log.info("email: {}", email);
 
 		RoleType roleType = RoleType.ROLE_USER;
 
@@ -41,11 +43,12 @@ public class OAuth2UserCustomService extends DefaultOAuth2UserService {
 		Member member;
 		try {
 			member = memberService.findByUsername(email);
+			log.info("get member");
 		} catch (MemberNotFoundException e) {
 			member = memberService.createMember(roleType, socialType, "닉네임");
+			log.info("create member");
 		}
 
-		return CurrentUser.create(member.getId(), roleType, socialType,
-			email);
+		return CurrentUser.create(member.getId(), roleType, socialType, email);
 	}
 }

--- a/src/main/java/today/sesac/shoutify/auth/service/OAuth2UserCustomService.java
+++ b/src/main/java/today/sesac/shoutify/auth/service/OAuth2UserCustomService.java
@@ -14,6 +14,9 @@ import today.sesac.shoutify.member.entity.SocialType;
 import today.sesac.shoutify.member.exception.MemberNotFoundException;
 import today.sesac.shoutify.member.service.MemberService;
 
+/**
+ * 소셜 로그인 과정에서
+ */
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -24,7 +27,9 @@ public class OAuth2UserCustomService extends DefaultOAuth2UserService {
 	@Override
 	public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
 		OAuth2User oAuth2User = super.loadUser(userRequest);
+		log.info("oAuth2User: {}", oAuth2User);
 
+		// 소셜 로그인 타입 확인
 		String registrationId = userRequest.getClientRegistration().getRegistrationId();
 		log.info("loadUser.registrationId: {}", registrationId);
 		SocialType socialType = null;
@@ -33,20 +38,22 @@ public class OAuth2UserCustomService extends DefaultOAuth2UserService {
 		}
 		log.info("socialType: {}", socialType);
 
-		// TODO: oauth2User 형식에 맞게 변환
+		// 사용자 정보 확인
 		String email = oAuth2User.getAttribute("email");
 		log.info("email: {}", email);
+		String nickname = oAuth2User.getAttribute("name");
+		log.info("nickname: {}", nickname); // TODO: 현재는 프로필의 이름을 그대로 받는 중, 변경 필요
 
+		// 사용자 역할 확인
 		RoleType roleType = RoleType.ROLE_USER;
 
+		// 사용자 정보가 없으면 db에 저장, 있으면 불러오기
 		// TODO: 확인하고 없으면 새로 만들기
 		Member member;
 		try {
 			member = memberService.findByUsername(email);
-			log.info("get member");
 		} catch (MemberNotFoundException e) {
-			member = memberService.createMember(roleType, socialType, "닉네임");
-			log.info("create member");
+			member = memberService.createMember(roleType, socialType, email, nickname);
 		}
 
 		return CurrentUser.create(member.getId(), roleType, socialType, email);

--- a/src/main/java/today/sesac/shoutify/auth/service/OAuth2UserCustomService.java
+++ b/src/main/java/today/sesac/shoutify/auth/service/OAuth2UserCustomService.java
@@ -1,0 +1,51 @@
+package today.sesac.shoutify.auth.service;
+
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import today.sesac.shoutify.member.entity.Member;
+import today.sesac.shoutify.member.entity.RoleType;
+import today.sesac.shoutify.member.entity.SocialType;
+import today.sesac.shoutify.member.exception.MemberNotFoundException;
+import today.sesac.shoutify.member.service.MemberService;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class OAuth2UserCustomService extends DefaultOAuth2UserService {
+
+	private final MemberService memberService;
+
+	@Override
+	public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+		OAuth2User oAuth2User = super.loadUser(userRequest);
+
+		String registrationId = userRequest.getClientRegistration().getRegistrationId();
+		log.info("loadUser.registrationId: {}", registrationId);
+		SocialType socialType = null;
+		if (registrationId.equals("google")) {
+			socialType = SocialType.GOOGLE;
+		}
+
+		// TODO: oauth2User 형식에 맞게 변환
+		String email = oAuth2User.getAttribute("email");
+
+		RoleType roleType = RoleType.ROLE_USER;
+
+		// TODO: 확인하고 없으면 새로 만들기
+		Member member;
+		try {
+			member = memberService.findByUsername(email);
+		} catch (MemberNotFoundException e) {
+			member = memberService.createMember(roleType, socialType, "닉네임");
+		}
+
+		return CurrentUser.create(member.getId(), roleType, socialType,
+			email);
+	}
+}

--- a/src/main/java/today/sesac/shoutify/member/entity/Member.java
+++ b/src/main/java/today/sesac/shoutify/member/entity/Member.java
@@ -1,6 +1,13 @@
 package today.sesac.shoutify.member.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -13,29 +20,32 @@ import today.sesac.shoutify.global.domain.BaseEntity;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member extends BaseEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
 
-    @NotNull
-    @Enumerated(EnumType.STRING)
-    private RoleType roleType;
+	@NotNull
+	@Enumerated(EnumType.STRING)
+	private RoleType roleType;
 
-    @NotNull
-    @Enumerated(EnumType.STRING)
-    private SocialType socialType;
+	@NotNull
+	@Enumerated(EnumType.STRING)
+	private SocialType socialType;
 
-    @NotNull
-    @Column(length = 50)
-    private String nickname;
+	// TODO: id 외에도 특정할 수 있는 필드 이름 정하기(이메일은? 이메일 이름은 같지만 소셜 로그인이 다른 경우 떄문에 안됨)
+	private String username;
 
-    private Member(RoleType roleType, SocialType socialType, String nickname) {
-        this.roleType = roleType;
-        this.socialType = socialType;
-        this.nickname = nickname;
-    }
+	@NotNull
+	@Column(length = 50)
+	private String nickname;
 
-    public static Member create(RoleType roleType, SocialType socialType, String nickname) {
-        return new Member(roleType, socialType, nickname);
-    }
+	private Member(RoleType roleType, SocialType socialType, String nickname) {
+		this.roleType = roleType;
+		this.socialType = socialType;
+		this.nickname = nickname;
+	}
+
+	public static Member create(RoleType roleType, SocialType socialType, String nickname) {
+		return new Member(roleType, socialType, nickname);
+	}
 }

--- a/src/main/java/today/sesac/shoutify/member/entity/Member.java
+++ b/src/main/java/today/sesac/shoutify/member/entity/Member.java
@@ -33,19 +33,21 @@ public class Member extends BaseEntity {
 	private SocialType socialType;
 
 	// TODO: id 외에도 특정할 수 있는 필드 이름 정하기(이메일은? 이메일 이름은 같지만 소셜 로그인이 다른 경우 떄문에 안됨)
+	// TODO: 현재는 email 저장 중, 이후 email 필드 따로 만들고 username에는 이메일에 몇 가지 고유 정보를 더해서 구분할 수 있게 만들 예정
 	private String username;
 
 	@NotNull
 	@Column(length = 50)
 	private String nickname;
 
-	private Member(RoleType roleType, SocialType socialType, String nickname) {
+	private Member(RoleType roleType, SocialType socialType, String username, String nickname) {
 		this.roleType = roleType;
 		this.socialType = socialType;
+		this.username = username;
 		this.nickname = nickname;
 	}
 
-	public static Member create(RoleType roleType, SocialType socialType, String nickname) {
-		return new Member(roleType, socialType, nickname);
+	public static Member create(RoleType roleType, SocialType socialType, String username, String nickname) {
+		return new Member(roleType, socialType, username, nickname);
 	}
 }

--- a/src/main/java/today/sesac/shoutify/member/exception/MemberAlreadyExistException.java
+++ b/src/main/java/today/sesac/shoutify/member/exception/MemberAlreadyExistException.java
@@ -1,0 +1,9 @@
+package today.sesac.shoutify.member.exception;
+
+import today.sesac.shoutify.global.exception.AbstractBaseException;
+
+public class MemberAlreadyExistException extends AbstractBaseException {
+	public MemberAlreadyExistException(String param, String errorMessage) {
+		super(MemberErrorCode.MEMBER_ALREADY_EXIST, param, errorMessage);
+	}
+}

--- a/src/main/java/today/sesac/shoutify/member/exception/MemberErrorCode.java
+++ b/src/main/java/today/sesac/shoutify/member/exception/MemberErrorCode.java
@@ -1,0 +1,20 @@
+package today.sesac.shoutify.member.exception;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import today.sesac.shoutify.global.exception.IErrorCode;
+
+@Getter
+public enum MemberErrorCode implements IErrorCode {
+	MEMBER_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "이미 존재하는 회원입니다."),
+	MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "회원이 존재하지 않습니다.");
+
+	private final HttpStatus httpStatus;
+	private final String message;
+
+	MemberErrorCode(HttpStatus httpStatus, String message) {
+		this.httpStatus = httpStatus;
+		this.message = message;
+	}
+}

--- a/src/main/java/today/sesac/shoutify/member/exception/MemberNotFoundException.java
+++ b/src/main/java/today/sesac/shoutify/member/exception/MemberNotFoundException.java
@@ -1,0 +1,9 @@
+package today.sesac.shoutify.member.exception;
+
+import today.sesac.shoutify.global.exception.AbstractBaseException;
+
+public class MemberNotFoundException extends AbstractBaseException {
+	public MemberNotFoundException(String param, String errorMessage) {
+		super(MemberErrorCode.MEMBER_NOT_FOUND, param, errorMessage);
+	}
+}

--- a/src/main/java/today/sesac/shoutify/member/repository/MemberRepository.java
+++ b/src/main/java/today/sesac/shoutify/member/repository/MemberRepository.java
@@ -1,9 +1,13 @@
 package today.sesac.shoutify.member.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+
 import today.sesac.shoutify.member.entity.Member;
 
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
+	Optional<Member> findByUsername(String username);
 }

--- a/src/main/java/today/sesac/shoutify/member/service/MemberService.java
+++ b/src/main/java/today/sesac/shoutify/member/service/MemberService.java
@@ -18,14 +18,23 @@ public class MemberService {
 	/**
 	 * TODO: 서비스와 나머지(ex.controller) 사이도 DTO로 통신하기?
 	 */
-	public void createMember(RoleType roleType, SocialType socialType, String nickname) {
+	public Member createMember(RoleType roleType, SocialType socialType, String nickname) {
 		Member member = Member.create(roleType, socialType, nickname);
-		memberRepository.save(member);
+		Member savedMember = memberRepository.save(member);
+		return savedMember;
 	}
 
 	public Member findById(Long memberId) {
 		Member member = memberRepository.findById(memberId).orElseThrow(
 			() -> new MemberNotFoundException(String.valueOf(memberId), "해당 id를 가진 회원을 찾을 수 없습니다."));
+		return member;
+	}
+
+	// TODO: username? Email? 구분 어떻게 할지 정하기
+	public Member findByUsername(String username) {
+		Member member = memberRepository.findByUsername(username).orElseThrow(
+			() -> new MemberNotFoundException(String.valueOf(username), "해당 username을 가진 회원을 찾을 수 없습니다.")
+		);
 		return member;
 	}
 

--- a/src/main/java/today/sesac/shoutify/member/service/MemberService.java
+++ b/src/main/java/today/sesac/shoutify/member/service/MemberService.java
@@ -3,12 +3,14 @@ package today.sesac.shoutify.member.service;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import today.sesac.shoutify.member.entity.Member;
 import today.sesac.shoutify.member.entity.RoleType;
 import today.sesac.shoutify.member.entity.SocialType;
 import today.sesac.shoutify.member.exception.MemberNotFoundException;
 import today.sesac.shoutify.member.repository.MemberRepository;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class MemberService {
@@ -19,6 +21,8 @@ public class MemberService {
 	 * TODO: 서비스와 나머지(ex.controller) 사이도 DTO로 통신하기?
 	 */
 	public Member createMember(RoleType roleType, SocialType socialType, String nickname) {
+		log.info("MemberService - createMember: roleType = {}, socialType = {}, nickname = {}", roleType, socialType,
+			nickname);
 		Member member = Member.create(roleType, socialType, nickname);
 		Member savedMember = memberRepository.save(member);
 		return savedMember;

--- a/src/main/java/today/sesac/shoutify/member/service/MemberService.java
+++ b/src/main/java/today/sesac/shoutify/member/service/MemberService.java
@@ -1,12 +1,32 @@
 package today.sesac.shoutify.member.service;
 
-import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import today.sesac.shoutify.member.entity.Member;
+import today.sesac.shoutify.member.entity.RoleType;
+import today.sesac.shoutify.member.entity.SocialType;
+import today.sesac.shoutify.member.exception.MemberNotFoundException;
 import today.sesac.shoutify.member.repository.MemberRepository;
 
 @Service
 @RequiredArgsConstructor
 public class MemberService {
 
-    private final MemberRepository memberRepository;
+	private final MemberRepository memberRepository;
+
+	/**
+	 * TODO: 서비스와 나머지(ex.controller) 사이도 DTO로 통신하기?
+	 */
+	public void createMember(RoleType roleType, SocialType socialType, String nickname) {
+		Member member = Member.create(roleType, socialType, nickname);
+		memberRepository.save(member);
+	}
+
+	public Member findById(Long memberId) {
+		Member member = memberRepository.findById(memberId).orElseThrow(
+			() -> new MemberNotFoundException(String.valueOf(memberId), "해당 id를 가진 회원을 찾을 수 없습니다."));
+		return member;
+	}
+
 }

--- a/src/main/java/today/sesac/shoutify/member/service/MemberService.java
+++ b/src/main/java/today/sesac/shoutify/member/service/MemberService.java
@@ -20,10 +20,10 @@ public class MemberService {
 	/**
 	 * TODO: 서비스와 나머지(ex.controller) 사이도 DTO로 통신하기?
 	 */
-	public Member createMember(RoleType roleType, SocialType socialType, String nickname) {
-		log.info("MemberService - createMember: roleType = {}, socialType = {}, nickname = {}", roleType, socialType,
-			nickname);
-		Member member = Member.create(roleType, socialType, nickname);
+	public Member createMember(RoleType roleType, SocialType socialType, String username, String nickname) {
+		log.info("createMember: roleType = {}, socialType = {}, username = {}, nickname = {}",
+			roleType, socialType, username, nickname);
+		Member member = Member.create(roleType, socialType, username, nickname);
 		Member savedMember = memberRepository.save(member);
 		return savedMember;
 	}
@@ -39,6 +39,8 @@ public class MemberService {
 		Member member = memberRepository.findByUsername(username).orElseThrow(
 			() -> new MemberNotFoundException(String.valueOf(username), "해당 username을 가진 회원을 찾을 수 없습니다.")
 		);
+		log.info("findByUsername: roleType = {}, socialType = {}, username = {}, nickname = {}",
+			member.getRoleType(), member.getSocialType(), member.getUsername(), member.getNickname());
 		return member;
 	}
 

--- a/src/main/java/today/sesac/shoutify/member/service/MemberService.java
+++ b/src/main/java/today/sesac/shoutify/member/service/MemberService.java
@@ -19,22 +19,33 @@ public class MemberService {
 
 	/**
 	 * TODO: 서비스와 나머지(ex.controller) 사이도 DTO로 통신하기?
+	 * @param roleType
+	 * @param socialType
+	 * @param username
+	 * @param nickname
+	 * @return
 	 */
 	public Member createMember(RoleType roleType, SocialType socialType, String username, String nickname) {
-		log.info("createMember: roleType = {}, socialType = {}, username = {}, nickname = {}",
-			roleType, socialType, username, nickname);
 		Member member = Member.create(roleType, socialType, username, nickname);
 		Member savedMember = memberRepository.save(member);
+		log.info("createMember: roleType = {}, socialType = {}, username = {}, nickname = {}",
+			roleType, socialType, username, nickname);
 		return savedMember;
 	}
 
+	/**
+	 * 회원의 id로 db에서 회원의 정보를 조회합니다.
+	 * @param memberId 회원의 id
+	 * @return Member 객체
+	 */
 	public Member findById(Long memberId) {
 		Member member = memberRepository.findById(memberId).orElseThrow(
 			() -> new MemberNotFoundException(String.valueOf(memberId), "해당 id를 가진 회원을 찾을 수 없습니다."));
+		log.info("findById: roleType = {}, socialType = {}, username = {}, nickname = {}",
+			member.getRoleType(), member.getSocialType(), member.getUsername(), member.getNickname());
 		return member;
 	}
 
-	// TODO: username? Email? 구분 어떻게 할지 정하기
 	public Member findByUsername(String username) {
 		Member member = memberRepository.findByUsername(username).orElseThrow(
 			() -> new MemberNotFoundException(String.valueOf(username), "해당 username을 가진 회원을 찾을 수 없습니다.")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,6 +30,7 @@ spring:
             client-secret: ${GOOGLE_CLIENT_SECRET}
             scope:
               - email
+              - profile
 
 # log level 설정, 예: trace, debug, info, warn, error
 logging:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,6 +21,16 @@ spring:
     resources:
       add-mappings: false # 404인 경우, static 리소스 참고하지 않고, 예외 핸들러에서 처리하도록 함.
 
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: ${GOOGLE_CLIENT_ID}
+            client-secret: ${GOOGLE_CLIENT_SECRET}
+            scope:
+              - email
+
 # log level 설정, 예: trace, debug, info, warn, error
 logging:
   level:

--- a/src/test/java/today/sesac/shoutify/auth/config/TestSecurityConfig.java
+++ b/src/test/java/today/sesac/shoutify/auth/config/TestSecurityConfig.java
@@ -1,0 +1,26 @@
+package today.sesac.shoutify.auth.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+/**
+ *  테스트에 사용되는 스프링 시큐리티 설정을 관리하는 클래스입니다
+ *  테스트에는 기존에 설정한 스프링 시큐리티 설정이 반영되지 않기 때문에, 별도의 클래스를 작성합니다.
+ */
+@TestConfiguration
+public class TestSecurityConfig {
+
+	@Bean
+	public SecurityFilterChain testFilterChain(HttpSecurity http) throws Exception {
+		http
+			.csrf(AbstractHttpConfigurer::disable) // post 요청에 발생하는 csrf 요청
+			.authorizeHttpRequests(auth -> auth
+				.anyRequest().permitAll() // TODO:
+			);
+
+		return http.build();
+	}
+}

--- a/src/test/java/today/sesac/shoutify/global/advice/GlobalExceptionHandlerTest.java
+++ b/src/test/java/today/sesac/shoutify/global/advice/GlobalExceptionHandlerTest.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
@@ -21,12 +22,14 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
+import today.sesac.shoutify.auth.config.TestSecurityConfig;
 import today.sesac.shoutify.global.exception.LoginRequiredException;
 import today.sesac.shoutify.global.exception.PermissionRequiredException;
 
 /**
  * 전역 예외 처리 테스트
  */
+@Import(TestSecurityConfig.class) //TODO: 테스트 커스텀 유저 추가 애노테이션 구현 필요
 @WebMvcTest(controllers = GlobalExceptionHandlerTest.class)
 class GlobalExceptionHandlerTest {
 

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -18,6 +18,15 @@ spring:
     resources:
       add-mappings: false # 404인 경우, static 리소스 참고하지 않고, 예외 핸들러에서 처리하도록 함.
 
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: ${GOOGLE_CLIENT_ID}
+            client-secret: ${GOOGLE_CLIENT_SECRET}
+            scope:
+              - email
 # log level 설정, 예: trace, debug, info, warn, error
 logging:
   level:


### PR DESCRIPTION
## 참고

현재 pr에 문제가 있어(브랜치 번호 잘못 맞춤) 클로즈하고 새로운 pr을 다시 올렸습니다. 아래에 올린 링크(42) 참고해주세요.

https://github.com/SproutJavaSesac/shoutify-backend/pull/42

## 작업 요약
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(무엇을, 왜) -->
다른 팀원들이 기능을 구현할 때 일관성 있게 회원 정보를 꺼내 쓸 수 있도록 빠르게 정상 동작만 하는 소셜 로그인을 구현하고, 회원 정보를 꺼내 쓰는 코드를 구현하고 공유합니다.

close #36 

### PR 타입

<!-- 하나 이상의 PR 타입을 선택해주세요. -->

- [x] 기능 구현
- [ ] 테스트 코드 작성
- [ ] 코드 리팩토링
- [ ] 문서 작성
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 작업 설명

### AS-IS

X

### TO-BE

- 스프링 시큐리티 의존성 추가 및 설정 추가
- 소셜 로그인(OAuth2) 설정 추가
- 소셜 로그인 설정을 위한 커스텀 클래스 추가(CurrentUser, OAuth2UserCustomService, OAuth2AuthenticationSuccessHandler)
- 회원 엔티티 수정(회원 식별할 수 있는 username 필드 추가 - 수정 예정)
- 팀원들이 회원 정보 꺼내 쓸 수 있도록 만들기

### 검증 방법

<!-- 리뷰하는 사람이 어떻게 테스트할 수 있을지 간략히 써주세요. (api 기대 응답 등, 000 test 완료, 000 테스트 코드 참고 등)
테스트 코드가 따로 없다면, 이후 테스트 계획(정상 시나리오 완료, 예외 구현 필요 등)을 적어 주세요. -->

1. 브라우저에 http://localhost:8080/api/oauth2/authorization/google 을 입력합니다
2. 구글에 로그인하거나 첫 로그인일 경우 정보 활용 동의를 진행합니다. 
3. 터미널에 다음과 같은 문구가 출력되면 로그인 완료(브라우저에 '사이트에 연결할 수 없음'라는 문구가 떠도 무시하셔도 됩니다)
<img width="836" alt="스크린샷 2025-06-22 오후 6 52 47" src="https://github.com/user-attachments/assets/747eae70-1687-4f96-9bed-b8ff37c1b817" />

## 리뷰 요구사항

<!-- 리뷰어가 집중해야 할 부분이 있다면 작성해주세요. 개발 과정에서 다른 분 사람의 의견이 궁금했거나 크로스 체크가 필요하다고 느껴진 코드 등 -->
- 한나님의 작성하신 GlobalExceptionHandlerTest 코드에 새로운 코드 한 줄 추가했습니다. 문제가 될 부분이 있으면 말씀해주세요
- 급하게 작성하느라 수정혹은 고민이 더 필요한 코드에 TODO로 주석을 남겼습니다. 좋은 의견이 있으면 남겨주세요~
- 미처 TODO 주석을 남기지 못한 코드들이 있습니다. 부족한 내용이 있으면 알려주세요!

<!--
## 이 PR이 merge된 후에 해야 할 일
- build를 다시 해야 하는 등 해야 하는 일 -->

## 기타

<!-- - 이 코드로 인해 우려되는 점(000 기능이 안 될 것 등) -->
<!-- - 문서 변경이 필요한 점 -->
<!-- - 논의가 필요한 일 -->

- 슬랙 secret 채널에 .env 파일 올렸습니다. **꼭 확인해주세요!!**

- 회원 정보를 꺼내 쓰는 방법

<img width="789" alt="스크린샷 2025-06-22 오후 7 11 12" src="https://github.com/user-attachments/assets/540ffa2f-ab15-4eb7-b260-c72c10fafc98" />

위 그림처럼 매개변수에 @AuthenticationPrincipal CurrentUser currentUser를 입력하면 현재 로그인한 사용자의 인증 정보를 확인할 수 있습니다. 
currentUser에는 사용자의 id(memberId)가 담겨있습니다. 그림처럼 currentUser.getMemberId()를 사용하면 사용자의 id를 꺼낼 수 있습니다.

- 포스트맨에서 '로그인한 상태'로 요청 보내기

로그인 상태가 필요한 기능(게시글 작성하기, 댓글 작성하기 등..)을 postman으로 테스트하려면 요청에 세션을 추가해야 합니다. 방법은 다음과 같습니다.

1. 로그인하기
위 '검증 방법'에 적어놓은 대로 로그인합니다.

2. 브라우저에서 세션id 가져오기

<img width="1098" alt="스크린샷 2025-06-22 오후 7 16 19" src="https://github.com/user-attachments/assets/58820624-1d27-4353-8938-94a32509eb58" />

위 그림처럼, 크롬 개발자 도구 - application탭 으로 이동 - 왼쪽의 Cookies에 들어가면 세션id(JSESSIONID)를 확인할 수 있습니다.

3. 세션id의 값을 postman 요청에 추가하기

<img width="812" alt="스크린샷 2025-06-22 오후 7 17 17" src="https://github.com/user-attachments/assets/c1d96fd7-dbdd-4fa9-b7b9-a51672eed3f0" />

헤더 탭에 들어가서, 쿠키값으로 세션 id를 추가합니다

4. 이후 각자 본인이 하려는 요청(게시글 작성하기, 댓글 작성하기 등..)을 테스트하시면 됩니다!


## 확인 사항

- [x] label, project, milestone 할당했나요?
- [x] 내 코드에 대해 self-review 진행했나요?(draft pr 발행 -> self-review -> Assignees 할당)
- [ ] 내 코드가 project 규칙에 만족하나요?(주석, 코드 스타일, 불필요한 import문 제거 등)
- [x] sonarlint, IDE, log 등에서 새로운 warning이 없는 걸 확인했나요?
- [x] 모든 테스트에 통과하는 걸 확인했나요?
- [ ] 필요한 문서 생성/수정이 진행되었나요?