### PR TITLE
[#43] 댓글 생성&조회&삭제 구현

### DIFF
--- a/src/main/java/today/sesac/shoutify/comment/controller/CommentController.java
+++ b/src/main/java/today/sesac/shoutify/comment/controller/CommentController.java
@@ -3,6 +3,7 @@ package today.sesac.shoutify.comment.controller;
 import java.util.List;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -59,5 +60,22 @@ public class CommentController {
 		List<CommentResponse> comments = commentService.getCommentsByPostId(postId);
 
 		return ResponseEntity.ok(ApiResponse.success(comments));
+	}
+
+	/**
+	 * 댓글을 삭제합니다.
+	 *
+	 * @param postId    게시글 ID
+	 * @param commentId 삭제할 댓글 ID
+	 * @return 삭제 성공 메시지
+	 */
+	@DeleteMapping("/{commentId}")
+	public ResponseEntity<ApiResponse<String>> deleteComment(
+		@PathVariable Long postId,
+		@PathVariable Long commentId
+	) {
+		commentService.deleteComment(postId, commentId);
+
+		return ResponseEntity.ok(ApiResponse.success("댓글이 삭제되었습니다."));
 	}
 }

--- a/src/main/java/today/sesac/shoutify/comment/controller/CommentController.java
+++ b/src/main/java/today/sesac/shoutify/comment/controller/CommentController.java
@@ -1,6 +1,9 @@
 package today.sesac.shoutify.comment.controller;
 
+import java.util.List;
+
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -41,5 +44,20 @@ public class CommentController {
 		CommentResponse response = commentService.createComment(postId, authorId, request);
 
 		return ResponseEntity.ok(ApiResponse.success(response));
+	}
+
+	/**
+	 * 특정 게시글의 댓글 목록을 조회합니다.
+	 *
+	 * @param postId 댓글을 조회할 게시글의 ID
+	 * @return 댓글 목록
+	 */
+	@GetMapping
+	public ResponseEntity<ApiResponse<List<CommentResponse>>> getComments(
+		@PathVariable Long postId
+	) {
+		List<CommentResponse> comments = commentService.getCommentsByPostId(postId);
+
+		return ResponseEntity.ok(ApiResponse.success(comments));
 	}
 }

--- a/src/main/java/today/sesac/shoutify/comment/controller/CommentController.java
+++ b/src/main/java/today/sesac/shoutify/comment/controller/CommentController.java
@@ -1,0 +1,45 @@
+package today.sesac.shoutify.comment.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import today.sesac.shoutify.comment.dto.CommentRequest;
+import today.sesac.shoutify.comment.dto.CommentResponse;
+import today.sesac.shoutify.comment.service.CommentService;
+import today.sesac.shoutify.global.response.ApiResponse;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/posts/{postId}/comments")
+public class CommentController {
+
+	private final CommentService commentService;
+
+	/**
+	 * 특정 게시글에 댓글을 작성합니다.
+	 *
+	 * @param postId  댓글을 작성할 게시글의 ID
+	 * @param request 댓글 내용, 작성자 ID, 대댓글 여부를 포함하는 요청 객체
+	// * @param currentUser 현재 로그인한 사용자 정보
+	 * @return 댓글 작성 성공 여부 및 메시지
+	 */
+	@PostMapping
+	public ResponseEntity<ApiResponse<CommentResponse>> createComment(
+		@PathVariable Long postId,
+		// @AuthenticationPrincipal CurrentUser currentUser,
+		@Valid @RequestBody CommentRequest request
+	) {
+		// Long authorId = currentUser.getMemberId();
+		Long authorId = 1L;
+
+		CommentResponse response = commentService.createComment(postId, authorId, request);
+
+		return ResponseEntity.ok(ApiResponse.success(response));
+	}
+}

--- a/src/main/java/today/sesac/shoutify/comment/dto/CommentRequest.java
+++ b/src/main/java/today/sesac/shoutify/comment/dto/CommentRequest.java
@@ -1,0 +1,16 @@
+package today.sesac.shoutify.comment.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CommentRequest {
+
+	@NotBlank
+	@Size(max = 500)
+	private String content;
+	private Long parentId;
+}

--- a/src/main/java/today/sesac/shoutify/comment/dto/CommentResponse.java
+++ b/src/main/java/today/sesac/shoutify/comment/dto/CommentResponse.java
@@ -1,0 +1,61 @@
+package today.sesac.shoutify.comment.dto;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Getter;
+import today.sesac.shoutify.comment.entity.Comment;
+
+@Getter
+public class CommentResponse {
+
+	private Long id;
+	private Long postId;
+	private Long authorId;
+	private String authorName; // 작성자명 추가
+	private Long parentId;
+	private String content;
+	private int likeCount;
+	private boolean isDeleted;
+	private boolean isReported;
+	private LocalDateTime createdAt;
+	private int level;
+	private List<CommentResponse> replies;
+
+	@Builder
+	public CommentResponse(Long id, Long postId, Long authorId, String authorName, Long parentId,
+		String content, int likeCount, boolean isDeleted, boolean isReported,
+		LocalDateTime createdAt, int level, List<CommentResponse> replies) {
+		this.id = id;
+		this.postId = postId;
+		this.authorId = authorId;
+		this.authorName = authorName;
+		this.parentId = parentId;
+		this.content = content;
+		this.likeCount = likeCount;
+		this.isDeleted = isDeleted;
+		this.isReported = isReported;
+		this.createdAt = createdAt;
+		this.level = level;
+		this.replies = replies != null ? replies : Collections.emptyList();
+	}
+
+	public static CommentResponse from(Comment comment) {
+		return CommentResponse.builder()
+			.id(comment.getId())
+			.postId(comment.getPost().getId())
+			.authorId(comment.getAuthor().getId())
+			.authorName(comment.getAuthor().getNickname())
+			.parentId(null) // 현재 대댓글 기능 미사용
+			.content(comment.getAfterContent()) // AI 변환된 내용 사용
+			.likeCount(0) // 현재 좋아요 기능 미구현
+			.isDeleted(comment.isDeleted())
+			.isReported(comment.isReported())
+			.createdAt(comment.getCreatedAt())
+			.level(comment.getLevel())
+			.replies(Collections.emptyList()) // 현재 대댓글 미사용
+			.build();
+	}
+}

--- a/src/main/java/today/sesac/shoutify/comment/entity/Comment.java
+++ b/src/main/java/today/sesac/shoutify/comment/entity/Comment.java
@@ -35,13 +35,13 @@ public class Comment extends BaseEntity {
 	 * AI 변환 전 사용자가 입력한 원본 댓글
 	 */
 	@Column(length = 500, nullable = false)
-	private String beforeContents;
+	private String beforeContent;
 
 	/**
 	 * AI가 변환한 후의 댓글 내용
 	 */
 	@Column(length = 500, nullable = false)
-	private String afterContents;
+	private String afterContent;
 
 	/**
 	 * 댓글이 작성된 게시물
@@ -75,9 +75,9 @@ public class Comment extends BaseEntity {
 	@Column(nullable = false, columnDefinition = "TINYINT(1)")
 	private boolean isReported;
 
-	private Comment(String beforeContents, String afterContents, Post post, Member author) {
-		this.beforeContents = beforeContents;
-		this.afterContents = afterContents;
+	private Comment(String beforeContent, String afterContent, Post post, Member author) {
+		this.beforeContent = beforeContent;
+		this.afterContent = afterContent;
 		this.post = post;
 		this.author = author;
 		this.level = 0;
@@ -85,7 +85,7 @@ public class Comment extends BaseEntity {
 		this.isReported = false;
 	}
 
-	public static Comment create(String beforeContents, String afterContents, Post post, Member author) {
-		return new Comment(beforeContents, afterContents, post, author);
+	public static Comment create(String beforeContent, String afterContent, Post post, Member author) {
+		return new Comment(beforeContent, afterContent, post, author);
 	}
 }

--- a/src/main/java/today/sesac/shoutify/comment/repository/CommentRepository.java
+++ b/src/main/java/today/sesac/shoutify/comment/repository/CommentRepository.java
@@ -1,5 +1,7 @@
 package today.sesac.shoutify.comment.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -7,4 +9,6 @@ import today.sesac.shoutify.comment.entity.Comment;
 
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+	List<Comment> findByPostId(Long postId);
 }

--- a/src/main/java/today/sesac/shoutify/comment/repository/CommentRepository.java
+++ b/src/main/java/today/sesac/shoutify/comment/repository/CommentRepository.java
@@ -3,6 +3,9 @@ package today.sesac.shoutify.comment.repository;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import today.sesac.shoutify.comment.entity.Comment;
@@ -11,4 +14,8 @@ import today.sesac.shoutify.comment.entity.Comment;
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
 	List<Comment> findByPostId(Long postId);
+
+	@Modifying
+	@Query("UPDATE Comment c SET c.isDeleted = true WHERE c.id = :id")
+	int softDeleteById(@Param("id") Long id);
 }

--- a/src/main/java/today/sesac/shoutify/comment/service/CommentService.java
+++ b/src/main/java/today/sesac/shoutify/comment/service/CommentService.java
@@ -1,12 +1,56 @@
 package today.sesac.shoutify.comment.service;
 
-import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import today.sesac.shoutify.comment.dto.CommentRequest;
+import today.sesac.shoutify.comment.dto.CommentResponse;
+import today.sesac.shoutify.comment.entity.Comment;
 import today.sesac.shoutify.comment.repository.CommentRepository;
+import today.sesac.shoutify.member.entity.Member;
+import today.sesac.shoutify.member.entity.RoleType;
+import today.sesac.shoutify.member.entity.SocialType;
+import today.sesac.shoutify.post.entity.Post;
+import today.sesac.shoutify.post.repository.PostRespository;
 
 @Service
 @RequiredArgsConstructor
 public class CommentService {
 
-    private final CommentRepository commentRepository;
+	private final CommentRepository commentRepository;
+	private final PostRespository postRepository;
+
+	/**
+	 * 댓글을 생성하고 저장합니다.
+	 *
+	 * @param postId   댓글이 달리는 게시글 ID
+	 * @param authorId 댓글 작성자 ID
+	 * @param request  댓글 요청 정보 (내용, parentId 등)
+	 * @return CommentResponse DTO
+	 */
+	@Transactional
+	public CommentResponse createComment(Long postId, Long authorId, CommentRequest request) {
+		// 게시글 존재 확인
+		Post post = postRepository.findById(postId)
+			.orElseThrow(() -> new IllegalArgumentException("게시글이 존재하지 않습니다."));
+
+		// 실제 서비스에서는 주석 처리된 코드로 대체
+		// Member author = memberService.findById(authorId);
+		Member author = Member.create(RoleType.ROLE_USER, SocialType.GOOGLE, "test");
+
+		// 댓글 객체 생성
+		Comment comment = Comment.create(
+			request.getContent(), // beforeContent
+			request.getContent(), // afterContent (AI 미처리 상태)
+			post,
+			author
+		);
+
+		// DB에 저장
+		Comment savedComment = commentRepository.save(comment);
+
+		// 엔티티를 DTO로 변환해서 반환
+		return CommentResponse.from(savedComment);
+	}
 }

--- a/src/main/java/today/sesac/shoutify/comment/service/CommentService.java
+++ b/src/main/java/today/sesac/shoutify/comment/service/CommentService.java
@@ -1,5 +1,7 @@
 package today.sesac.shoutify.comment.service;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -54,5 +56,26 @@ public class CommentService {
 
 		// 엔티티를 DTO로 변환해서 반환
 		return CommentResponse.from(savedComment);
+	}
+
+	/**
+	 * 특정 게시글의 댓글 목록을 조회합니다.
+	 *
+	 * @param postId 댓글을 조회할 게시글 ID
+	 * @return 댓글 목록
+	 */
+	@Transactional(readOnly = true)
+	public List<CommentResponse> getCommentsByPostId(Long postId) {
+		// 게시글 존재 확인
+		Post post = postRepository.findById(postId)
+			.orElseThrow(() -> new IllegalArgumentException("게시글이 존재하지 않습니다."));
+
+		// 댓글 목록 조회 (삭제되지 않은 댓글만, 생성일 순으로 정렬)
+		List<Comment> comments = commentRepository.findByPostId(postId);
+
+		// DTO로 변환해서 반환
+		return comments.stream()
+			.map(CommentResponse::from)
+			.toList();
 	}
 }

--- a/src/main/java/today/sesac/shoutify/comment/service/CommentService.java
+++ b/src/main/java/today/sesac/shoutify/comment/service/CommentService.java
@@ -9,8 +9,7 @@ import today.sesac.shoutify.comment.dto.CommentResponse;
 import today.sesac.shoutify.comment.entity.Comment;
 import today.sesac.shoutify.comment.repository.CommentRepository;
 import today.sesac.shoutify.member.entity.Member;
-import today.sesac.shoutify.member.entity.RoleType;
-import today.sesac.shoutify.member.entity.SocialType;
+import today.sesac.shoutify.member.repository.MemberRepository;
 import today.sesac.shoutify.post.entity.Post;
 import today.sesac.shoutify.post.repository.PostRespository;
 
@@ -20,6 +19,7 @@ public class CommentService {
 
 	private final CommentRepository commentRepository;
 	private final PostRespository postRepository;
+	private final MemberRepository memberRepository; //변경 예정
 
 	/**
 	 * 댓글을 생성하고 저장합니다.
@@ -31,13 +31,15 @@ public class CommentService {
 	 */
 	@Transactional
 	public CommentResponse createComment(Long postId, Long authorId, CommentRequest request) {
+
 		// 게시글 존재 확인
 		Post post = postRepository.findById(postId)
 			.orElseThrow(() -> new IllegalArgumentException("게시글이 존재하지 않습니다."));
 
 		// 실제 서비스에서는 주석 처리된 코드로 대체
 		// Member author = memberService.findById(authorId);
-		Member author = Member.create(RoleType.ROLE_USER, SocialType.GOOGLE, "test");
+		Member author = memberRepository.findById(authorId)
+			.orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
 
 		// 댓글 객체 생성
 		Comment comment = Comment.create(

--- a/src/main/java/today/sesac/shoutify/comment/service/CommentService.java
+++ b/src/main/java/today/sesac/shoutify/comment/service/CommentService.java
@@ -78,4 +78,31 @@ public class CommentService {
 			.map(CommentResponse::from)
 			.toList();
 	}
+
+	/**
+	 * 댓글을 삭제합니다 (Soft Delete).
+	 *
+	 * @param postId    게시글 ID
+	 * @param commentId 삭제할 댓글 ID
+	 */
+	@Transactional
+	public void deleteComment(Long postId, Long commentId) {
+		// 게시글 존재 확인
+		Post post = postRepository.findById(postId)
+			.orElseThrow(() -> new IllegalArgumentException("게시글이 존재하지 않습니다."));
+
+		// 댓글 존재 확인 및 해당 게시글 댓글인지 확인
+		Comment comment = commentRepository.findById(commentId)
+			.orElseThrow(() -> new IllegalArgumentException("댓글이 존재하지 않습니다."));
+
+		if (!comment.getPost().getId().equals(postId)) {
+			throw new IllegalArgumentException("해당 게시글의 댓글이 아닙니다.");
+		}
+
+		// Soft Delete 실행
+		int updatedRows = commentRepository.softDeleteById(commentId);
+		if (updatedRows == 0) {
+			throw new IllegalArgumentException("댓글 삭제에 실패했습니다.");
+		}
+	}
 }


### PR DESCRIPTION
## 작업 요약
댓글 생성&조회&삭제 구현

### PR 타입
- [x] 기능 구현
- [ ] 테스트 코드 작성
- [ ] 코드 리팩토링
- [ ] 문서 작성
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 문제 해결

## 작업 설명

### AS-IS

### TO-BE
- 게시글에 댓글 작성 가능
- 게시글별 댓글 목록 조회 가능 
- 댓글 삭제 기능 (Soft Delete)

### 검증 방법

- 댓글 생성
POST /api/v1/posts/1/comments
Content-Type: application/json
```

{
   "content": "테스트 댓글입니다"
}

```
<img width="842" alt="스크린샷 2025-06-25 오전 3 49 57" src="https://github.com/user-attachments/assets/7857acaa-db4c-47d6-859f-f3ca49469291" />


- 댓글 목록 조회
GET /api/v1/posts/1/comments
![스크린샷 2025-06-25 오전 3 34 15](https://github.com/user-attachments/assets/0efa21fc-1cb5-4c15-b93f-3f2d9704c37d)

- 댓글 삭제
DELETE /api/v1/posts/1/comments/1

## 리뷰 요구사항

### 참고
상준님 member pr 머지되면 회원 정보 불러오는 로직 수정하겠습니다

## 기타
기능 구현을 최우선으로 작성했습니다....
수정사항 알려주시면 감사하겠습니다


## 확인 사항

- [x] label, project, milestone 할당했나요?
- [x] 내 코드에 대해 self-review 진행했나요?(draft pr 발행 -> self-review -> Assignees 할당)
- [x] 내 코드가 project 규칙에 만족하나요?(주석, 코드 스타일, 불필요한 import문 제거 등)
- [x] sonarlint, IDE, log 등에서 새로운 warning이 없는 걸 확인했나요?
- [x] 모든 테스트에 통과하는 걸 확인했나요?
- [x] 필요한 문서 생성/수정이 진행되었나요?
